### PR TITLE
Remove duplicates from the help output

### DIFF
--- a/packages-available/Help/help.achel
+++ b/packages-available/Help/help.achel
@@ -21,4 +21,6 @@ if ~!Local,showHidden!~,==,,
 else
 	debug 1,Allowing hidden entries.
 
+keyOnPreserve name
+
 registerOnceForEvent Achel,finishEarly,finishHelp


### PR DESCRIPTION
These are caused by aliases, which are an intended feature.

So this PR simply removes them from the `--help` output.