### PR TITLE
Fix keys created during sort

### DIFF
--- a/packages-available/Manipulations/manipulator.php
+++ b/packages-available/Manipulations/manipulator.php
@@ -942,8 +942,10 @@ class Manipulator extends Module
 				$key='';
 				foreach ($keysToKeyOn as $keyPart)
 				{
-					$key.=(isset($item[$keyPart]))?$separator.$item[$keyPart]:$separator.$oldKey;
+					$sep=($key=='')?'':$separator;
+					$key.=(isset($item[$keyPart]))?$sep.$item[$keyPart]:$sep.$oldKey;
 				}
+
 				$this->debug(3, "keyOn: Derived key $key");
 			}
 			else


### PR DESCRIPTION
The separator was making it into the keys when sorting. This was leading to bugs in apps written in Achel due to keys not behaving as expected.