### PR TITLE
Fix plural for fuzzytime

### DIFF
--- a/packages-available/TimeThing/time.php
+++ b/packages-available/TimeThing/time.php
@@ -161,8 +161,15 @@ class TimeThing extends Module
 			}
 		}
 
+		// Almost done.
 		$output="$value $unit";
-		if (intval($value)!=1) $output.='s';
+
+		// Cater to plurals.
+		if (intval($value)!=1 or strpos($value, '.'))
+		{
+			$output.='s';
+		}
+
 		return $output;
 	}
 


### PR DESCRIPTION
For 1.x values, fuzzyTime would incorrectly make it sigular instead of plural.

This one has been _sliiiiiightly_ annoying me for years. Now it won't. :)