### PR TITLE
Gracefully handle empty input time for fuzzyTime

### DIFF
--- a/packages-available/TimeThing/time.php
+++ b/packages-available/TimeThing/time.php
@@ -105,6 +105,10 @@ class TimeThing extends Module
 	{
 		$accuracy=1;
 
+		if ($inputTime=='') {
+			return "No time";
+		}
+
 		if ($inputTime < 0)
 		{
 			$sign="-";

--- a/packages-available/TimeThing/ttUnitTests.achel
+++ b/packages-available/TimeThing/ttUnitTests.achel
@@ -92,3 +92,6 @@ defineTest FuzzyTime - -300,
 	fuzzyTime Local,fTime,-300
 	expect -5 minutes,~!Local,fTime!~
 
+defineTest FuzzyTime - No time,
+	fuzzyTime Local,fTime,
+	expect No time,~!Local,fTime!~


### PR DESCRIPTION
An empty input time in fuzzyTime was causing a fatal error before. Now it doesn't.